### PR TITLE
Don't capture quotes in console.log snippet

### DIFF
--- a/log.sublime-snippet
+++ b/log.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-	<content><![CDATA[console.log(${1:'test'});]]></content>
+	<content><![CDATA[console.log('${1:test}');]]></content>
 	<tabTrigger>log</tabTrigger>
 	<description>JS - Log to console</description>
 	<scope>source.js</scope>


### PR DESCRIPTION
When i add a log statement, most of the time i want to print a string in the console. With the current snippet, i have to type `log` -> TAB -> Backspace -> `'` -> `string`. With the proposed modification, i only have to type `log` -> TAB -> `string`.
